### PR TITLE
#80feature/getchallenge top10

### DIFF
--- a/src/main/java/com/bod/bod/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/bod/bod/challenge/controller/ChallengeController.java
@@ -25,75 +25,75 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChallengeController {
 
-	private final ChallengeService challengeService;
+  private final ChallengeService challengeService;
 
-	@PostMapping("/{challengeId}")
-	public ResponseEntity<CommonResponseDto<ChallengeResponseDto>> addChallenge(
-		@PathVariable("challengeId") Long challengeId,
-		@AuthenticationPrincipal UserDetailsImpl userDetails
-	) {
-		//로그인 한 유저정보
-		String username = userDetails.getUsername();
-		ChallengeResponseDto challenge = challengeService.addUserToChallenge(challengeId, username);
+  @PostMapping("/{challengeId}")
+  public ResponseEntity<CommonResponseDto<ChallengeResponseDto>> addChallenge(
+	  @PathVariable("challengeId") Long challengeId,
+	  @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+	//로그인 한 유저정보
+	String username = userDetails.getUsername();
+	ChallengeResponseDto challenge = challengeService.addUserToChallenge(challengeId, username);
 
-		return ResponseEntity.ok().body(new CommonResponseDto<>
-			(HttpStatus.OK.value(), "챌린지 등록 성공", challenge));
-	}
+	return ResponseEntity.ok().body(new CommonResponseDto<>
+		(HttpStatus.OK.value(), "챌린지 등록 성공", challenge));
+  }
 
-	@GetMapping("/category")
-	public ResponseEntity<CommonResponseDto<List<ChallengeSummaryResponseDto>>> getChallengeListByCategory(
-		@RequestParam(value = "page", defaultValue = "1") int page,
-		@RequestParam Category category
-	) {
-		List<ChallengeSummaryResponseDto> challengeList = challengeService.getChallengesByCategory(
-			page - 1, category);
-		return ResponseEntity.ok().body(new CommonResponseDto<>
-			(HttpStatus.OK.value(), "카테고리별 챌린지 조회 성공", challengeList));
-	}
+  @GetMapping("/category")
+  public ResponseEntity<CommonResponseDto<List<ChallengeSummaryResponseDto>>> getChallengeListByCategory(
+	  @RequestParam(value = "page", defaultValue = "1") int page,
+	  @RequestParam Category category
+  ) {
+	List<ChallengeSummaryResponseDto> challengeList = challengeService.getChallengesByCategory(
+		page - 1, category);
+	return ResponseEntity.ok().body(new CommonResponseDto<>
+		(HttpStatus.OK.value(), "카테고리별 챌린지 조회 성공", challengeList));
+  }
 
-	@GetMapping
-	public ResponseEntity<CommonResponseDto<List<ChallengeSummaryResponseDto>>> getAllChallenge(
-		@RequestParam(value = "page", defaultValue = "1") int page
-	) {
-		List<ChallengeSummaryResponseDto> challengeList = challengeService.getAllChallenges(
-			page - 1);
-		return ResponseEntity.ok().body(new CommonResponseDto<>
-			(HttpStatus.OK.value(), "챌린지 전체 조회 성공", challengeList));
-	}
+  @GetMapping
+  public ResponseEntity<CommonResponseDto<List<ChallengeSummaryResponseDto>>> getAllChallenge(
+	  @RequestParam(value = "page", defaultValue = "1") int page
+  ) {
+	List<ChallengeSummaryResponseDto> challengeList = challengeService.getAllChallenges(
+		page - 1);
+	return ResponseEntity.ok().body(new CommonResponseDto<>
+		(HttpStatus.OK.value(), "챌린지 전체 조회 성공", challengeList));
+  }
 
-	@GetMapping("/{challengeId}")
-	public ResponseEntity<CommonResponseDto<ChallengeResponseDto>> getChallengeDetails(
-		@PathVariable("challengeId") Long challengeId
-	) {
-		ChallengeResponseDto challenge = challengeService.getChallengeDetails(challengeId);
-		return ResponseEntity.ok().body(new CommonResponseDto<>
-			(HttpStatus.OK.value(), "챌린지 단건 조회 성공", challenge));
-	}
+  @GetMapping("/{challengeId}")
+  public ResponseEntity<CommonResponseDto<ChallengeResponseDto>> getChallengeDetails(
+	  @PathVariable("challengeId") Long challengeId
+  ) {
+	ChallengeResponseDto challenge = challengeService.getChallengeDetails(challengeId);
+	return ResponseEntity.ok().body(new CommonResponseDto<>
+		(HttpStatus.OK.value(), "챌린지 단건 조회 성공", challenge));
+  }
 
-	@GetMapping("/{challengeId}/users")
-	public ResponseEntity<CommonResponseDto<List<ChallengeUserListDto>>> getUserByChallenges(
-		@PathVariable("challengeId") Long challengeId
-	) {
-		List<ChallengeUserListDto> userList = challengeService.getChallengesByUser(challengeId);
+  @GetMapping("/{challengeId}/users")
+  public ResponseEntity<CommonResponseDto<List<ChallengeUserListDto>>> getUserByChallenges(
+	  @PathVariable("challengeId") Long challengeId
+  ) {
+	List<ChallengeUserListDto> userList = challengeService.getChallengesByUser(challengeId);
 
-		return ResponseEntity.ok().body(new CommonResponseDto<>(
-			HttpStatus.OK.value(), "선택한 챌린지의 유저 조회 성공", userList));
-	}
+	return ResponseEntity.ok().body(new CommonResponseDto<>(
+		HttpStatus.OK.value(), "선택한 챌린지의 유저 조회 성공", userList));
+  }
 
-	@DeleteMapping("/{challengeId}")
-	public ResponseEntity<CommonResponseDto<List<ChallengeUserListDto>>> deleteChallenge(
-		@PathVariable("challengeId") long challengeId,
-		@AuthenticationPrincipal UserDetailsImpl userDetails
-	) {
-		challengeService.deleteChallenge(challengeId, userDetails.getUser());
-		return ResponseEntity.ok().body(new CommonResponseDto<>(
-			HttpStatus.OK.value(), "선택한 챌린지 삭제 성공", null));
-	}
+  @DeleteMapping("/{challengeId}")
+  public ResponseEntity<CommonResponseDto<List<ChallengeUserListDto>>> deleteChallenge(
+	  @PathVariable("challengeId") long challengeId,
+	  @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+	challengeService.deleteChallenge(challengeId, userDetails.getUser());
+	return ResponseEntity.ok().body(new CommonResponseDto<>(
+		HttpStatus.OK.value(), "선택한 챌린지 삭제 성공", null));
+  }
 
-	@GetMapping("/top10")
+  @GetMapping("/top10")
   public ResponseEntity<CommonResponseDto<List<ChallengeSummaryResponseDto>>> getTop10Challenges() {
-	  List<ChallengeSummaryResponseDto> getTop10ChallengeList = challengeService.getTop10Challenges();
-	  return ResponseEntity.ok().body(new CommonResponseDto<>(
-		  HttpStatus.OK.value(), "챌린지 top10 리스트 조회 성공", getTop10ChallengeList));
-	}
+	List<ChallengeSummaryResponseDto> getTop10ChallengeList = challengeService.getTop10Challenges();
+	return ResponseEntity.ok().body(new CommonResponseDto<>(
+		HttpStatus.OK.value(), "챌린지 top10 리스트 조회 성공", getTop10ChallengeList));
+  }
 }

--- a/src/main/java/com/bod/bod/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/bod/bod/challenge/controller/ChallengeController.java
@@ -89,4 +89,11 @@ public class ChallengeController {
 		return ResponseEntity.ok().body(new CommonResponseDto<>(
 			HttpStatus.OK.value(), "선택한 챌린지 삭제 성공", null));
 	}
+
+	@GetMapping("/top10")
+  public ResponseEntity<CommonResponseDto<List<ChallengeSummaryResponseDto>>> getTop10Challenges() {
+	  List<ChallengeSummaryResponseDto> getTop10ChallengeList = challengeService.getTop10Challenges();
+	  return ResponseEntity.ok().body(new CommonResponseDto<>(
+		  HttpStatus.OK.value(), "챌린지 top10 리스트 조회 성공", getTop10ChallengeList));
+	}
 }

--- a/src/main/java/com/bod/bod/challenge/repository/ChallengeCustomRepository.java
+++ b/src/main/java/com/bod/bod/challenge/repository/ChallengeCustomRepository.java
@@ -8,5 +8,6 @@ public interface ChallengeCustomRepository {
 
   List<ChallengeSummaryResponseDto> getChallengeListByCategory(int page, Category category);
   List<ChallengeSummaryResponseDto> getChallengeList(int page);
+  List<ChallengeSummaryResponseDto> findTop10ChallengesByUserchallenges();
 
 }

--- a/src/main/java/com/bod/bod/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/com/bod/bod/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.bod.bod.challenge.repository;
 import com.bod.bod.challenge.dto.ChallengeSummaryResponseDto;
 import com.bod.bod.challenge.entity.Category;
 import com.bod.bod.challenge.entity.QChallenge;
-import com.querydsl.core.types.OrderSpecifier;
+import com.bod.bod.userchallenge.entity.QUserChallenge;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -48,5 +48,21 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
 		.fetch();
 	return challengeList;
   }
+
+  public List<ChallengeSummaryResponseDto> findTop10ChallengesByUserchallenges() {
+	QChallenge challenge = QChallenge.challenge;
+	QUserChallenge userChallenge = QUserChallenge.userChallenge;
+
+	List<ChallengeSummaryResponseDto> top10ChallengeList = queryFactory
+		.select((Projections.constructor(ChallengeSummaryResponseDto.class, challenge)))
+		.from(userChallenge)
+		.join(userChallenge.challenge, challenge)
+		.groupBy(challenge)
+		.orderBy(userChallenge.challenge.count().desc())
+		.limit(10)
+		.fetch();
+	return top10ChallengeList;
+  }
+
 
 }

--- a/src/main/java/com/bod/bod/challenge/service/ChallengeService.java
+++ b/src/main/java/com/bod/bod/challenge/service/ChallengeService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +26,7 @@ public class ChallengeService {
     private final UserRepository userRepository;
     private final UserChallengeRepository userChallengeRepository;
 
+    @Transactional(readOnly = true)
     public List<ChallengeSummaryResponseDto> getChallengesByCategory(int page, Category category) {
         List<ChallengeSummaryResponseDto> challengeList = challengeRepository.getChallengeListByCategory(page, category);
         if (challengeList.isEmpty()) {
@@ -33,6 +35,7 @@ public class ChallengeService {
         return challengeList;
     }
 
+    @Transactional(readOnly = true)
     public List<ChallengeSummaryResponseDto> getAllChallenges(int page) {
         List<ChallengeSummaryResponseDto> challengeList = challengeRepository.getChallengeList(page);
         if (challengeList.isEmpty()) {
@@ -41,11 +44,13 @@ public class ChallengeService {
         return challengeList;
     }
 
+    @Transactional(readOnly = true)
     public ChallengeResponseDto getChallengeDetails(Long challengeId) {
         Challenge challenge = findById(challengeId);
         return new ChallengeResponseDto(challenge);
     }
 
+    @Transactional
     public ChallengeResponseDto addUserToChallenge(Long challengeId, String username){
 
         User user = userRepository.findByUsername(username)
@@ -65,6 +70,7 @@ public class ChallengeService {
         return new ChallengeResponseDto(challenge);
     }
 
+    @Transactional(readOnly = true)
     public List<ChallengeUserListDto> getChallengesByUser(Long challengeId) {
 
         Challenge challenge = challengeRepository.findChallengeById(challengeId);
@@ -75,6 +81,7 @@ public class ChallengeService {
             .toList();
     }
 
+    @Transactional
     public void deleteChallenge(long challengeId, User user) {
         UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(user, findById(challengeId))
             .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_USER_CHALLENGE));
@@ -82,7 +89,17 @@ public class ChallengeService {
         userChallengeRepository.delete(userChallenge);
     }
 
+    @Transactional(readOnly = true)
+    public List<ChallengeSummaryResponseDto> getTop10Challenges() {
+        List<ChallengeSummaryResponseDto> top10ChallengeList = challengeRepository.findTop10ChallengesByUserchallenges();
+        if (top10ChallengeList.isEmpty()) {
+            throw new GlobalException(ErrorCode.NOT_FOUND_CHALLENGE);
+        }
+        return top10ChallengeList;
+    }
+
     public Challenge findById(Long challengeId) {
         return challengeRepository.findChallengeById(challengeId);
     }
+
 }

--- a/src/main/java/com/bod/bod/global/config/WebConfig.java
+++ b/src/main/java/com/bod/bod/global/config/WebConfig.java
@@ -1,0 +1,29 @@
+package com.bod.bod.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+	registry.addMapping("/**")
+		.allowedOrigins("http://localhost:8081")
+		.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+		.allowCredentials(true)
+		.maxAge(3600);
+  }
+
+
+  @Override
+  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+	registry.addResourceHandler("/**")
+		.addResourceLocations("classpath:/META-INF/resources/")
+		.setCacheControl(CacheControl.noStore())
+		.setCachePeriod(0);
+  }
+}

--- a/src/main/java/com/bod/bod/global/config/WebConfig.java
+++ b/src/main/java/com/bod/bod/global/config/WebConfig.java
@@ -1,29 +1,29 @@
-package com.bod.bod.global.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.http.CacheControl;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-@Configuration
-public class WebConfig implements WebMvcConfigurer {
-
-  @Override
-  public void addCorsMappings(CorsRegistry registry) {
-	registry.addMapping("/**")
-		.allowedOrigins("http://localhost:8081")
-		.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-		.allowCredentials(true)
-		.maxAge(3600);
-  }
-
-
-  @Override
-  public void addResourceHandlers(ResourceHandlerRegistry registry) {
-	registry.addResourceHandler("/**")
-		.addResourceLocations("classpath:/META-INF/resources/")
-		.setCacheControl(CacheControl.noStore())
-		.setCachePeriod(0);
-  }
-}
+//package com.bod.bod.global.config;
+//
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.http.CacheControl;
+//import org.springframework.web.servlet.config.annotation.CorsRegistry;
+//import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+//
+//@Configuration
+//public class WebConfig implements WebMvcConfigurer {
+//
+//  @Override
+//  public void addCorsMappings(CorsRegistry registry) {
+//	registry.addMapping("/**")
+//		.allowedOrigins("http://localhost:8081")
+//		.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+//		.allowCredentials(true)
+//		.maxAge(3600);
+//  }
+//
+//
+//  @Override
+//  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+//	registry.addResourceHandler("/**")
+//		.addResourceLocations("classpath:/META-INF/resources/")
+//		.setCacheControl(CacheControl.noStore())
+//		.setCachePeriod(0);
+//  }
+//}

--- a/src/main/java/com/bod/bod/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/bod/bod/global/config/WebSecurityConfig.java
@@ -62,26 +62,4 @@ public class WebSecurityConfig {
 		return http.build();
 	}
 
-	@Bean
-	public WebMvcConfigurer corsConfigurer() {
-		return new WebMvcConfigurer() {
-
-			@Override
-			public void addCorsMappings(CorsRegistry registry) {
-				registry.addMapping("/**")
-					.allowedOrigins("http://localhost:8081")
-					.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
-			}
-
-			@Override
-			public void addResourceHandlers(ResourceHandlerRegistry registry) {
-				registry.addResourceHandler("/**")
-					.addResourceLocations("classpath:/META-INF/resources/");
-				registry.addResourceHandler("index.html")
-					.addResourceLocations("classpath:/META-INF/resources/")
-					.setCacheControl(CacheControl.noStore()) // 브라우저 resource 저장 사용 x
-					.setCachePeriod(0); // 서버 캐시 사용하지 않음.
-			}
-		};
-	}
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1714b0ba-9f43-46d5-b66f-dc96ac19ac02)
![image](https://github.com/user-attachments/assets/10a8b071-c085-4909-8f64-f870969ca596)

userchallenge테이블에 있는 challengeId의 개수가 가장 많은 순서대로 challenge리스트를 가져오는 형식으로 구현할 예정입니다.
즉, user들이 가장 많이 참여한 top10를 가져오는 기능입니다.

MainPage에서 전체 조회보다는 인기있는 챌린지 목록을 보여주는게 좋을 것 같아 해당 기능을 구현했습니다.
챌린지 전체조회는 상단바의 챌린지 버튼을 클릭하게되면 카테고리별 조회와 함께 사용할 예정입니다.