### PR TITLE
#92feature/challenge/verification top3 users

### DIFF
--- a/src/main/java/com/bod/bod/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/bod/bod/challenge/dto/ChallengeResponseDto.java
@@ -27,7 +27,7 @@ public class ChallengeResponseDto {
         this.challengeId = challenge.getId();
         this.title = challenge.getTitle();
         this.content = challenge.getContent();
-        this.image = challenge.getImage();
+        this.image = challenge.getImageUrl();
         this.category = challenge.getCategory();
         this.conditionStatus = challenge.getConditionStatus();
         this.startTime = challenge.getStartTime();

--- a/src/main/java/com/bod/bod/challenge/dto/ChallengeSummaryResponseDto.java
+++ b/src/main/java/com/bod/bod/challenge/dto/ChallengeSummaryResponseDto.java
@@ -12,11 +12,13 @@ public class ChallengeSummaryResponseDto {
   private Long id;
   private String title;
   private String content;
+  private String imageUrl;
   private Category category;
 
   public ChallengeSummaryResponseDto(Challenge challenge) {
 	this.id = challenge.getId();
 	this.title = challenge.getTitle();
+	this.imageUrl = challenge.getImageUrl();
 	this.content = challenge.getContent();
 	this.category = challenge.getCategory();
   }

--- a/src/main/java/com/bod/bod/verification/controller/VerificationController.java
+++ b/src/main/java/com/bod/bod/verification/controller/VerificationController.java
@@ -4,6 +4,7 @@ import com.bod.bod.global.dto.CommonResponseDto;
 import com.bod.bod.global.jwt.security.UserDetailsImpl;
 import com.bod.bod.verification.dto.VerificationRequestDto;
 import com.bod.bod.verification.dto.VerificationResponseDto;
+import com.bod.bod.verification.dto.VerificationTop3UserResponseDto;
 import com.bod.bod.verification.dto.VerificationWithUserResponseDto;
 import com.bod.bod.verification.service.VerificationService;
 import java.util.List;
@@ -58,6 +59,15 @@ public class VerificationController {
 	List<VerificationWithUserResponseDto> verificationList = verificationService.getVerificationsByChallengeId(page, challengeId);
 	return ResponseEntity.ok().body(new CommonResponseDto<>
 		(HttpStatus.OK.value(), "챌린지 인증신청 목록 조회 성공", verificationList));
+  }
+
+  @GetMapping("/challenges/{challengeId}/verifications/top3users")
+  public ResponseEntity<CommonResponseDto<List<VerificationTop3UserResponseDto>>> getTop3VerificationUsers(
+	  @PathVariable("challengeId") Long challengeId
+  ) {
+	List<VerificationTop3UserResponseDto> verificationUserList = verificationService.getTop3VerificationUsers(challengeId);
+	return ResponseEntity.ok().body(new CommonResponseDto<>
+		(HttpStatus.OK.value(), "챌린지 인증 상위 참여자 조회 성공", verificationUserList));
   }
 }
 

--- a/src/main/java/com/bod/bod/verification/dto/VerificationTop3UserResponseDto.java
+++ b/src/main/java/com/bod/bod/verification/dto/VerificationTop3UserResponseDto.java
@@ -1,0 +1,20 @@
+package com.bod.bod.verification.dto;
+
+import com.bod.bod.verification.entity.Verification;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VerificationTop3UserResponseDto {
+
+  private Long verificationId;
+  private String name;
+  private String nickname;
+
+  public VerificationTop3UserResponseDto(Verification verification) {
+	this.verificationId = verification.getId();
+	this.name = verification.getUser().getName();
+	this.nickname = verification.getUser().getNickname();
+  }
+}

--- a/src/main/java/com/bod/bod/verification/repository/VerificationCustomRepository.java
+++ b/src/main/java/com/bod/bod/verification/repository/VerificationCustomRepository.java
@@ -1,10 +1,11 @@
 package com.bod.bod.verification.repository;
 
+import com.bod.bod.verification.dto.VerificationTop3UserResponseDto;
 import com.bod.bod.verification.dto.VerificationWithUserResponseDto;
 import java.util.List;
 
 public interface VerificationCustomRepository {
 
   List<VerificationWithUserResponseDto> findVerificationWithUserByChallengeId(int page, Long challengeId);
-
+  List<VerificationTop3UserResponseDto> getTop3VerificationUsers(Long challengeId);
 }

--- a/src/main/java/com/bod/bod/verification/repository/VerificationCustomRepositoryImpl.java
+++ b/src/main/java/com/bod/bod/verification/repository/VerificationCustomRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.bod.bod.verification.repository;
 
 import com.bod.bod.challenge.entity.QChallenge;
+import com.bod.bod.verification.dto.VerificationTop3UserResponseDto;
 import com.bod.bod.verification.dto.VerificationWithUserResponseDto;
 import com.bod.bod.verification.entity.QVerification;
+import com.bod.bod.verification.entity.Status;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -33,5 +35,20 @@ public class VerificationCustomRepositoryImpl implements VerificationCustomRepos
 		.fetch();
 
 	return verificationList;
+  }
+
+  public List<VerificationTop3UserResponseDto> getTop3VerificationUsers(Long challengeId) {
+	QVerification verification = QVerification.verification;
+	QChallenge challenge = QChallenge.challenge;
+
+	List<VerificationTop3UserResponseDto> top3VerificationUserList = queryFactory
+		.select(Projections.constructor(VerificationTop3UserResponseDto.class, verification))
+		.from(verification)
+		.where(verification.challenge.id.eq(challengeId).and(verification.status.eq(Status.APPROVE)))
+		.groupBy(verification.user.id, verification.user.name, verification.user.nickname)
+		.orderBy(verification.user.id.count().desc())
+		.limit(3)
+		.fetch();
+	return top3VerificationUserList;
   }
 }

--- a/src/main/java/com/bod/bod/verification/service/VerificationService.java
+++ b/src/main/java/com/bod/bod/verification/service/VerificationService.java
@@ -11,6 +11,7 @@ import com.bod.bod.global.exception.GlobalException;
 import com.bod.bod.user.entity.User;
 import com.bod.bod.verification.dto.VerificationRequestDto;
 import com.bod.bod.verification.dto.VerificationResponseDto;
+import com.bod.bod.verification.dto.VerificationTop3UserResponseDto;
 import com.bod.bod.verification.dto.VerificationWithUserResponseDto;
 import com.bod.bod.verification.entity.Verification;
 import com.bod.bod.verification.repository.VerificationRepository;
@@ -79,6 +80,16 @@ public class VerificationService {
   public List<VerificationWithUserResponseDto> getVerificationsByChallengeId(int page, Long challengeId) {
     Challenge challenge = challengeService.findById(challengeId);
     List<VerificationWithUserResponseDto> responseDto = verificationRepository.findVerificationWithUserByChallengeId(page, challengeId);
+    if(responseDto.isEmpty()) {
+      throw new GlobalException(ErrorCode.EMPTY_VERIFICATION);
+    }
+    return responseDto;
+  }
+
+  @Transactional(readOnly = true)
+  public List<VerificationTop3UserResponseDto> getTop3VerificationUsers(Long challengeId) {
+    Challenge challenge = challengeService.findById(challengeId);
+    List<VerificationTop3UserResponseDto> responseDto = verificationRepository.getTop3VerificationUsers(challengeId);
     if(responseDto.isEmpty()) {
       throw new GlobalException(ErrorCode.EMPTY_VERIFICATION);
     }


### PR DESCRIPTION
챌린지 상세조회 시 상위참여자 부분이 있어서 챌린지 인증 상위 참여자 TOP 조회 기능 구현이 필요하다고 생각했습니다. 

챌린지 top3 user는 APPROVE된 인증 갯수가 많은 유저(인증신청한 날짜 내림차순)으로 조회 구현하였습니다.   

