### PR TITLE
feat / 챌린지 참가 인원 제한 기능구현, 비관적 락 으로 동시성 제어 구현

### DIFF
--- a/src/main/java/com/bod/bod/admin/dto/AdminChallengeCreateRequestDto.java
+++ b/src/main/java/com/bod/bod/admin/dto/AdminChallengeCreateRequestDto.java
@@ -1,6 +1,5 @@
 package com.bod.bod.admin.dto;
 
-import com.bod.bod.challenge.entity.ConditionStatus;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
@@ -18,5 +17,7 @@ public class AdminChallengeCreateRequestDto {
     private LocalDateTime startTime;
 
     private LocalDateTime endTime;
+
+    private Long limitedUsers;
 
 }

--- a/src/main/java/com/bod/bod/admin/dto/AdminChallengeCreateResponseDto.java
+++ b/src/main/java/com/bod/bod/admin/dto/AdminChallengeCreateResponseDto.java
@@ -29,6 +29,10 @@ public class AdminChallengeCreateResponseDto {
 
     private LocalDateTime createAt;
 
+    private Long limitedUsers;
+
+    private Long joinedUsers;
+
     public AdminChallengeCreateResponseDto(Challenge challenge) {
         this.challengeId = challenge.getId();
         this.title = challenge.getTitle();
@@ -39,6 +43,8 @@ public class AdminChallengeCreateResponseDto {
         this.startTime = challenge.getStartTime();
         this.endTime = challenge.getEndTime();
         this.createAt = challenge.getCreatedAt();
+        this.limitedUsers = challenge.getLimitedUsers();
+        this.joinedUsers = challenge.getJoinedUsers();
     }
 
 }

--- a/src/main/java/com/bod/bod/admin/dto/AdminChallengeResponseDto.java
+++ b/src/main/java/com/bod/bod/admin/dto/AdminChallengeResponseDto.java
@@ -25,6 +25,10 @@ public class AdminChallengeResponseDto {
 
     private String content;
 
+    private Long limitedUsers;
+
+    private Long joinedUsers;
+
     public AdminChallengeResponseDto(Challenge challenge) {
         this.challengeId = challenge.getId();
         this.title = challenge.getTitle();
@@ -33,5 +37,7 @@ public class AdminChallengeResponseDto {
         this.startTime = challenge.getStartTime();
         this.endTime = challenge.getEndTime();
         this.content = challenge.getContent();
+        this.limitedUsers = challenge.getLimitedUsers();
+        this.joinedUsers = challenge.getJoinedUsers();
     }
 }

--- a/src/main/java/com/bod/bod/admin/dto/AdminChallengeUpdateRequestDto.java
+++ b/src/main/java/com/bod/bod/admin/dto/AdminChallengeUpdateRequestDto.java
@@ -22,4 +22,6 @@ public class AdminChallengeUpdateRequestDto {
 
     private LocalDateTime endTime;
 
+    private Long limitedUsers;
+
 }

--- a/src/main/java/com/bod/bod/admin/dto/AdminChallengeUpdateResponseDto.java
+++ b/src/main/java/com/bod/bod/admin/dto/AdminChallengeUpdateResponseDto.java
@@ -29,6 +29,10 @@ public class AdminChallengeUpdateResponseDto {
 
     private LocalDateTime modifiedAt;
 
+    private Long limitedUsers;
+
+    private Long joinedUsers;
+
     public AdminChallengeUpdateResponseDto(Challenge challenge) {
         this.challengeId = challenge.getId();
         this.title = challenge.getTitle();
@@ -39,6 +43,8 @@ public class AdminChallengeUpdateResponseDto {
         this.endTime = challenge.getEndTime();
         this.createAt = challenge.getCreatedAt();
         this.modifiedAt = challenge.getModifiedAt();
+        this.limitedUsers = challenge.getLimitedUsers();
+        this.joinedUsers = challenge.getJoinedUsers();
     }
 
 }

--- a/src/main/java/com/bod/bod/admin/dto/AdminChallengesResponseDto.java
+++ b/src/main/java/com/bod/bod/admin/dto/AdminChallengesResponseDto.java
@@ -23,6 +23,10 @@ public class AdminChallengesResponseDto {
 
     private LocalDateTime endTime;
 
+    private Long limitedUsers;
+
+    private Long joinedUsers;
+
     public AdminChallengesResponseDto(Challenge challenge) {
         this.challengeId = challenge.getId();
         this.title = challenge.getTitle();
@@ -30,6 +34,8 @@ public class AdminChallengesResponseDto {
         this.conditionStatus = challenge.getConditionStatus();
         this.startTime = challenge.getStartTime();
         this.endTime = challenge.getEndTime();
+        this.limitedUsers = challenge.getLimitedUsers();
+        this.joinedUsers = challenge.getJoinedUsers();
     }
 
 

--- a/src/main/java/com/bod/bod/admin/service/AdminService.java
+++ b/src/main/java/com/bod/bod/admin/service/AdminService.java
@@ -112,16 +112,16 @@ public class AdminService {
             amazonS3Client.putObject(BUCKET, "challenge/" + image.getOriginalFilename(), image.getInputStream(), metadata);
 
             String imageUrl = amazonS3Client.getResourceUrl(BUCKET, "challenge/" + image.getOriginalFilename());
-            Category category = Category.valueOf(reqDto.getCategory());
             Challenge challenge = Challenge.builder()
                 .title(reqDto.getTitle())
                 .content(reqDto.getContent())
                 .image(image.getOriginalFilename())
                 .imageUrl(imageUrl)
-                .category(category)
+                .category(Category.valueOf(reqDto.getCategory()))
                 .conditionStatus(ConditionStatus.valueOf(reqDto.getConditionStatus()))
                 .startTime(reqDto.getStartTime())
                 .endTime(reqDto.getEndTime())
+                .limitedUsers(reqDto.getLimitedUsers())
                 .build();
             Challenge savedChallenge = challengeRepository.save(challenge);
             return new AdminChallengeCreateResponseDto(savedChallenge);
@@ -139,7 +139,7 @@ public class AdminService {
             .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_CHALLENGE));
 
         challenge.changeChallenge(reqDto.getTitle(), reqDto.getContent(), reqDto.getCategory(),
-            reqDto.getConditionStatus(), reqDto.getStartTime(), reqDto.getEndTime());
+            reqDto.getConditionStatus(), reqDto.getStartTime(), reqDto.getEndTime(), reqDto.getLimitedUsers());
 
         return new AdminChallengeUpdateResponseDto(challenge);
     }

--- a/src/main/java/com/bod/bod/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/bod/bod/challenge/dto/ChallengeResponseDto.java
@@ -21,6 +21,8 @@ public class ChallengeResponseDto {
     private LocalDateTime endTime;
     private LocalDateTime createAt;
     private int completionRate;
+    private Long limitedUsers;
+    private Long joinedUsers;
 
     // 기본 생성자
     public ChallengeResponseDto(Challenge challenge) {
@@ -33,6 +35,8 @@ public class ChallengeResponseDto {
         this.startTime = challenge.getStartTime();
         this.endTime = challenge.getEndTime();
         this.createAt = challenge.getCreatedAt();
+        this.limitedUsers = challenge.getLimitedUsers();
+        this.joinedUsers = challenge.getJoinedUsers();
     }
 
     public ChallengeResponseDto(Challenge challenge, int verificationCount) {

--- a/src/main/java/com/bod/bod/challenge/dto/ChallengeSummaryResponseDto.java
+++ b/src/main/java/com/bod/bod/challenge/dto/ChallengeSummaryResponseDto.java
@@ -14,6 +14,8 @@ public class ChallengeSummaryResponseDto {
   private String content;
   private String imageUrl;
   private Category category;
+  private Long limitedUsers;
+  private Long joinedUsers;
 
   public ChallengeSummaryResponseDto(Challenge challenge) {
 	this.id = challenge.getId();
@@ -21,5 +23,7 @@ public class ChallengeSummaryResponseDto {
 	this.imageUrl = challenge.getImageUrl();
 	this.content = challenge.getContent();
 	this.category = challenge.getCategory();
+    this.limitedUsers = challenge.getLimitedUsers();
+    this.joinedUsers = challenge.getJoinedUsers();
   }
 }

--- a/src/main/java/com/bod/bod/challenge/entity/Challenge.java
+++ b/src/main/java/com/bod/bod/challenge/entity/Challenge.java
@@ -62,17 +62,34 @@ public class Challenge extends TimeStamp {
     @Column(name = "end_time", nullable = false)
     private LocalDateTime endTime;
 
+    @Column(name = "limited_users", nullable = false)
+    private Long limitedUsers;
+
+    @Builder.Default
+    @Column(name = "joined_users", nullable = false)
+    private Long joinedUsers = 0L;
+
+
     @Builder.Default
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserChallenge> userChallenges = new ArrayList<>();
 
-    public void changeChallenge (String title, String content, Category category, ConditionStatus conditionStatus, LocalDateTime startTime, LocalDateTime endTime) {
+    public void changeChallenge (String title, String content, Category category, ConditionStatus conditionStatus, LocalDateTime startTime, LocalDateTime endTime, Long limitedUsers) {
         this.title = title;
         this.content = content;
         this.category = category;
         this.conditionStatus = conditionStatus;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.limitedUsers = limitedUsers;
+    }
+
+    public void increaseJoinedUsers() {
+        joinedUsers++;
+    }
+
+    public void decreaseJoinedUsers() {
+        joinedUsers--;
     }
 
 }

--- a/src/main/java/com/bod/bod/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/bod/bod/challenge/repository/ChallengeRepository.java
@@ -4,9 +4,15 @@ import com.bod.bod.challenge.entity.Category;
 import com.bod.bod.challenge.entity.Challenge;
 import com.bod.bod.global.exception.ErrorCode;
 import com.bod.bod.global.exception.GlobalException;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ChallengeCustomRepository {
 
@@ -18,4 +24,9 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long>, Cha
     Page<Challenge> findAll(Pageable pageable);
     Page<Challenge> findByCategory(Category category, Pageable pageable);
     Page<Challenge> findAllByOrderByCreatedAtAsc(Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})  // timeout 설정 (3초)
+    @Query("select c from Challenge c where c.id in :id")
+    Optional<Challenge> findByIdWithPessimisticLock(Long id);
 }

--- a/src/main/java/com/bod/bod/global/exception/ErrorCode.java
+++ b/src/main/java/com/bod/bod/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     NOT_FOUND_CHALLENGE(404, "해당 챌린지는 존재하지 않습니다."),
     DUPLICATE_CHALLENGE(409, "이미 신청한 챌린지입니다."),
     COMPLETE_CHALLENGE(400, "마감된 챌린지이므로 참여할 수 없습니다."),
+    LIMIT_FULL_CHALLENGE(400, "제한인원이 가득 차서 참여할 수 없습니다."),
 
     // Verification-related errors
     EMPTY_VERIFICATION(404, "해당 챌린지에는 현재까지 인증 신청 내역이 없습니다."),


### PR DESCRIPTION
챌린지 참가 인원 제한
 - 챌린지마다 참가 가능 인원에 제한을 설정
 - 인원이 다 찰 경우, 추가 인원 참가 불가
 - 필요한 api : (기존 api에 limitedUsers, joinedUsers request response 추가 및 로직 추가)
	<admin>
	 챌린지 등록 api에 req, res 추가
	 챌린지 수정 api에 req, res 추가
	 챌린지 전체조회 api에 res 추가
	 챌린지 단건조회 api에 res 추가
	<challenge>
	 챌린지 entity에 limitedUsers 추가
	 챌린지 entity에 joinedUsers 추가
	 챌린지 전체조회 api에 res 추가
	 챌린지 단건조회 api에 res 추가
	 챌린지 카테고리별조회 api에 res 추가
	 챌린지 참가 api에 로직 추가
	  - joinedUsers < limitedUsers 참가처리하고 joinedUsers ++;
	  - joinedUsers >= limitedUsers 예외처리
	 챌린지 참가취소 api에 로직 추가
	  - joinedUsers --;
	  
 - 선착순 개념, 락을 획득한 트랜잭션에서만 참가 신청가능, 획득하지 못한 트랜잭션은 읽기만 허용
 - 동시성제어 비관적 락 ( Shared lock, PESSIMISTIC_READ ) 적용
![image](https://github.com/user-attachments/assets/504ba548-ed4d-487d-943e-e1e72155de45)
