### PR TITLE
refactor : 챌린지등록, 인증요청 이미지 업로드 기능분리 리팩토링

### DIFF
--- a/src/main/java/com/bod/bod/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bod/bod/global/exception/GlobalExceptionHandler.java
@@ -72,4 +72,9 @@ public class GlobalExceptionHandler {
             .build();
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(InvalidFileTypeException.class)
+    public ResponseEntity<String> handleInvalidFileTypeException(InvalidFileTypeException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/bod/bod/global/exception/InvalidFileTypeException.java
+++ b/src/main/java/com/bod/bod/global/exception/InvalidFileTypeException.java
@@ -1,0 +1,8 @@
+package com.bod.bod.global.exception;
+
+public class InvalidFileTypeException extends RuntimeException {
+
+  public InvalidFileTypeException(String message) {
+	super(message);
+  }
+}

--- a/src/main/java/com/bod/bod/global/service/S3Service.java
+++ b/src/main/java/com/bod/bod/global/service/S3Service.java
@@ -1,11 +1,23 @@
 package com.bod.bod.global.service;
 
+import com.bod.bod.challenge.entity.Challenge;
+import com.bod.bod.verification.entity.Verification;
 import java.io.IOException;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface S3Service {
 
-	String upload(MultipartFile multipartFile) throws IOException;
+  String upload(MultipartFile multipartFile) throws IOException;
 
-	void deleteFromS3(String fileName);
+  void deleteFromS3(String fileName);
+
+  @Transactional
+  String imageUpload(MultipartFile image, String key);
+
+  @Transactional
+  void deleteChallengeImage(Challenge challenge, String key);
+
+  @Transactional
+  void deleteVerificationImage(Verification verification, String key);
 }

--- a/src/main/java/com/bod/bod/global/service/S3ServiceImpl.java
+++ b/src/main/java/com/bod/bod/global/service/S3ServiceImpl.java
@@ -1,11 +1,19 @@
 package com.bod.bod.global.service;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.bod.bod.challenge.entity.Challenge;
 import com.bod.bod.global.exception.ErrorCode;
+import com.bod.bod.global.exception.FileUploadFailureException;
 import com.bod.bod.global.exception.GlobalException;
+import com.bod.bod.global.exception.InvalidFileTypeException;
+import com.bod.bod.verification.entity.Verification;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,73 +33,118 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class S3ServiceImpl implements S3Service {
 
-	private final AmazonS3 amazonS3;
+  private final AmazonS3 amazonS3;
+  private final AmazonS3Client amazonS3Client;
 
-	@Value("${cloud.aws.s3.bucket}")
-	private String bucket;
+  @Value("${cloud.aws.s3.bucket}")
+  private String BUCKET;
 
-	@Value("${spring.servlet.multipart.max-file-size}")
-	private String maxFileSize;
+  @Value("${spring.servlet.multipart.max-file-size}")
+  private String maxFileSize;
 
-	@Override
-	public String upload(MultipartFile multipartFile) throws IOException {
+  @Override
+  public String upload(MultipartFile multipartFile) throws IOException {
 
-		if (multipartFile.getSize() > parseSize(maxFileSize)) {
-			throw new GlobalException(ErrorCode.FILE_UPLOAD_ERROR);
-		}
-		File uploadFile = convertToFile(multipartFile)
-			.orElseThrow(() -> new GlobalException(ErrorCode.FILE_CONVERSION_ERROR));
-		return uploadToS3(uploadFile);
+	if (multipartFile.getSize() > parseSize(maxFileSize)) {
+	  throw new GlobalException(ErrorCode.FILE_UPLOAD_ERROR);
 	}
+	File uploadFile = convertToFile(multipartFile)
+		.orElseThrow(() -> new GlobalException(ErrorCode.FILE_CONVERSION_ERROR));
+	return uploadToS3(uploadFile);
+  }
 
-	private String uploadToS3(File uploadFile) {
-		String fileName = "profile-images" + "/" + UUID.randomUUID() + "-" + uploadFile.getName();
-		putS3(uploadFile, fileName);
-		deleteLocalFile(uploadFile);
-		return fileName;
+  @Override
+  public void deleteFromS3(String fileName) {
+	try {
+	  amazonS3.deleteObject(new DeleteObjectRequest(BUCKET, fileName));
+	} catch (Exception e) {
+	  throw new GlobalException(ErrorCode.FILE_UPLOAD_ERROR);
 	}
+  }
 
-	private void putS3(File uploadFile, String fileName) {
-		amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+  @Override
+  public String imageUpload(MultipartFile image, String key) {
+	if (image.isEmpty()) {
+	  throw new GlobalException(ErrorCode.EMPTY_FILE);
 	}
+	fileSizeExceed(image);
+	allowedImageTypes(image);
+	try {
+	  ObjectMetadata metadata = new ObjectMetadata();
+	  metadata.setContentType(image.getContentType());
+	  metadata.setContentLength(image.getSize());
+	  amazonS3Client.putObject(BUCKET, key + image.getOriginalFilename(), image.getInputStream(), metadata);
+	  String imageUrl = amazonS3Client.getResourceUrl(BUCKET, key + image.getOriginalFilename());
+	  return imageUrl;
+	} catch (IOException e) {
+	  throw new FileUploadFailureException("파일 업로드 실패");
+	}
+  }
 
-	private void deleteLocalFile(File targetFile) {
-		if (targetFile.delete()) {
-			log.info("파일 삭제 성공: {}", targetFile.getName());
-		} else {
-			throw new GlobalException(ErrorCode.FILE_UPLOAD_ERROR);
-		}
-	}
+  @Override
+  public void deleteChallengeImage(Challenge challenge, String key) {
+	DeleteObjectRequest request = new DeleteObjectRequest(BUCKET, key + challenge.getImage());
+	amazonS3Client.deleteObject(request);
+  }
 
-	@Override
-	public void deleteFromS3(String fileName) {
-		try {
-			amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
-		} catch (Exception e) {
-			throw new GlobalException(ErrorCode.FILE_UPLOAD_ERROR);
-		}
-	}
+  @Override
+  public void deleteVerificationImage(Verification verification, String key) {
+	DeleteObjectRequest request = new DeleteObjectRequest(BUCKET, key + verification.getImageName());
+	amazonS3Client.deleteObject(request);
+  }
 
-	private Optional<File> convertToFile(MultipartFile file) throws IOException {
-		File convertFile = new File(System.getProperty("user.dir") + "/" + file.getOriginalFilename());
-		if (convertFile.createNewFile()) {
-			try (FileOutputStream fos = new FileOutputStream(convertFile)) {
-				fos.write(file.getBytes());
-			}
-			return Optional.of(convertFile);
-		}
-		return Optional.empty();
-	}
+  private String uploadToS3(File uploadFile) {
+	String fileName = "profile-images" + "/" + UUID.randomUUID() + "-" + uploadFile.getName();
+	putS3(uploadFile, fileName);
+	deleteLocalFile(uploadFile);
+	return fileName;
+  }
 
-	private long parseSize(String size) {
-		if (size.endsWith("MB")) {
-			return Long.parseLong(size.replace("MB", "")) * 1024 * 1024;
-		} else if (size.endsWith("KB")) {
-			return Long.parseLong(size.replace("KB", "")) * 1024;
-		} else if (size.endsWith("GB")) {
-			return Long.parseLong(size.replace("GB", "")) * 1024 * 1024 * 1024;
-		} else {
-			return Long.parseLong(size);
-		}
+  private void putS3(File uploadFile, String fileName) {
+	amazonS3.putObject(new PutObjectRequest(BUCKET, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+  }
+
+  private void deleteLocalFile(File targetFile) {
+	if (targetFile.delete()) {
+	  log.info("파일 삭제 성공: {}", targetFile.getName());
+	} else {
+	  throw new GlobalException(ErrorCode.FILE_UPLOAD_ERROR);
 	}
+  }
+
+  private Optional<File> convertToFile(MultipartFile file) throws IOException {
+	File convertFile = new File(System.getProperty("user.dir") + "/" + file.getOriginalFilename());
+	if (convertFile.createNewFile()) {
+	  try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+		fos.write(file.getBytes());
+	  }
+	  return Optional.of(convertFile);
+	}
+	return Optional.empty();
+  }
+
+  private long parseSize(String size) {
+	if (size.endsWith("MB")) {
+	  return Long.parseLong(size.replace("MB", "")) * 1024 * 1024;
+	} else if (size.endsWith("KB")) {
+	  return Long.parseLong(size.replace("KB", "")) * 1024;
+	} else if (size.endsWith("GB")) {
+	  return Long.parseLong(size.replace("GB", "")) * 1024 * 1024 * 1024;
+	} else {
+	  return Long.parseLong(size);
+	}
+  }
+
+  private void fileSizeExceed(MultipartFile image) {
+	if (image.getSize() > parseSize(maxFileSize)) {
+	  throw new GlobalException(ErrorCode.FILE_UPLOAD_ERROR);
+	}
+  }
+
+  private void allowedImageTypes(MultipartFile image) {
+	String fileName = image.getOriginalFilename();
+	if (fileName == null || !fileName.matches(".*\\.(jpg|jpeg|png|gif)$")) {
+	  throw new InvalidFileTypeException("지원되지 않는 파일 형식입니다: " + fileName);
+	}
+  }
 }

--- a/src/main/java/com/bod/bod/verification/service/VerificationService.java
+++ b/src/main/java/com/bod/bod/verification/service/VerificationService.java
@@ -1,14 +1,11 @@
 package com.bod.bod.verification.service;
 
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.bod.bod.global.dto.PaginationResponse;
 import com.bod.bod.challenge.entity.Challenge;
 import com.bod.bod.challenge.service.ChallengeService;
+import com.bod.bod.global.dto.PaginationResponse;
 import com.bod.bod.global.exception.ErrorCode;
-import com.bod.bod.global.exception.FileUploadFailureException;
 import com.bod.bod.global.exception.GlobalException;
+import com.bod.bod.global.service.S3Service;
 import com.bod.bod.user.entity.User;
 import com.bod.bod.verification.dto.VerificationRequestDto;
 import com.bod.bod.verification.dto.VerificationResponseDto;
@@ -18,13 +15,11 @@ import com.bod.bod.verification.dto.VerificationWithUserResponseDto;
 import com.bod.bod.verification.entity.Status;
 import com.bod.bod.verification.entity.Verification;
 import com.bod.bod.verification.repository.VerificationRepository;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -38,22 +33,10 @@ public class VerificationService {
 
   private final VerificationRepository verificationRepository;
   private final ChallengeService challengeService;
-  private final AmazonS3Client amazonS3Client;
-
-  @Value("${cloud.aws.s3.bucket}")
-  private String BUCKET;
+  private final S3Service s3Service;
 
   @Transactional
   public VerificationResponseDto requestVerification(Long challengeId, MultipartFile image, VerificationRequestDto requestDto, User user) {
-    try {
-      if(image.isEmpty()) {
-        throw new GlobalException(ErrorCode.EMPTY_FILE);
-      }
-      ObjectMetadata metadata= new ObjectMetadata();
-      metadata.setContentType(image.getContentType());
-      metadata.setContentLength(image.getSize());
-      amazonS3Client.putObject(BUCKET, "verification/" + image.getOriginalFilename(), image.getInputStream(), metadata);
-
       Challenge challenge = challengeService.findById(challengeId);
 
       LocalDateTime currentDateTime = LocalDateTime.now();
@@ -68,15 +51,11 @@ public class VerificationService {
       if(checkVerification) {
        throw new GlobalException(ErrorCode.ALREADY_EXISTS_VERIFICATION);
       }
-
-      String imageUrl= amazonS3Client.getResourceUrl(BUCKET, "verification/" + image.getOriginalFilename());
+      String key = "verification/";
+      String imageUrl = s3Service.imageUpload(image, key);
       Verification verification = new Verification(requestDto.getTitle(), requestDto.getContent(), image.getOriginalFilename(), imageUrl, challenge, user);
       verificationRepository.save(verification);
       return new VerificationResponseDto(verification.getId(), verification.getTitle(), verification.getContent(), imageUrl, verification.getStatus());
-
-    } catch(IOException e) {
-      throw new FileUploadFailureException("파일 업로드 실패");
-    }
   }
 
   @Transactional
@@ -86,8 +65,8 @@ public class VerificationService {
       throw new GlobalException(ErrorCode.DO_NOT_CANCEL_VERIFICATION);
     }
     verification.checkUser(user);
-    DeleteObjectRequest request = new DeleteObjectRequest(BUCKET, "verification/" + verification.getImageName());
-    amazonS3Client.deleteObject(request);
+    String key = "verification/";
+    s3Service.deleteVerificationImage(verification, key);
     verificationRepository.delete(verification);
   }
 

--- a/src/main/java/com/bod/bod/verification/service/VerificationService.java
+++ b/src/main/java/com/bod/bod/verification/service/VerificationService.java
@@ -39,18 +39,8 @@ public class VerificationService {
   public VerificationResponseDto requestVerification(Long challengeId, MultipartFile image, VerificationRequestDto requestDto, User user) {
       Challenge challenge = challengeService.findById(challengeId);
 
-      LocalDateTime currentDateTime = LocalDateTime.now();
-      LocalDate currentDate = currentDateTime.toLocalDate();
-      LocalDateTime startOfDay = currentDate.atStartOfDay();
-      LocalDateTime endOfDay = currentDate.atTime(LocalTime.MAX);
+      duplicateVerification(challengeId, user);
 
-      boolean checkVerification = verificationRepository.existsByChallengeIdAndUserAndCreatedAtBetween(
-          challengeId, user, startOfDay, endOfDay
-      );
-
-      if(checkVerification) {
-       throw new GlobalException(ErrorCode.ALREADY_EXISTS_VERIFICATION);
-      }
       String key = "verification/";
       String imageUrl = s3Service.imageUpload(image, key);
       Verification verification = new Verification(requestDto.getTitle(), requestDto.getContent(), image.getOriginalFilename(), imageUrl, challenge, user);
@@ -111,4 +101,18 @@ public class VerificationService {
     return verificationRepository.findVerificationById(verificationId);
   }
 
+  private void duplicateVerification(Long challengeId, User user) {
+    LocalDateTime currentDateTime = LocalDateTime.now();
+    LocalDate currentDate = currentDateTime.toLocalDate();
+    LocalDateTime startOfDay = currentDate.atStartOfDay();
+    LocalDateTime endOfDay = currentDate.atTime(LocalTime.MAX);
+
+    boolean checkVerification = verificationRepository.existsByChallengeIdAndUserAndCreatedAtBetween(
+        challengeId, user, startOfDay, endOfDay
+    );
+
+    if(checkVerification) {
+      throw new GlobalException(ErrorCode.ALREADY_EXISTS_VERIFICATION);
+    }
+  }
 }

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,8 +1,8 @@
 ## datasource
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://${ENDPOINT}:3306/challenge
-spring.datasource.username=${MYSQL_USER}
-spring.datasource.password=${MYSQL_PASSWORD}
+spring.datasource.url=jdbc:mysql://${ENDPOINT}:3306/${DATABASE_NAME}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
 
 # JPA ??
 spring.jpa.hibernate.ddl-auto=update
@@ -16,6 +16,7 @@ jwt.access-expire-time=${JWT_ACCESS_EXPIRE_TIME}
 jwt.refresh-expire-time=${JWT_REFRESH_EXPIRE_TIME}
 
 # Maximum file size for upload
+spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 


### PR DESCRIPTION
챌린지 등록과 인증요청시 이미지업로드 기능은 따로 s3Sevice에서 처리하도록 분리하였습니다.
혹시 더 좋은 방법이 있다면 피드백 주시면 감사하겠습니다!

포스트맨과 버킷에 정상적으로 작동하는지 까지 테스트 완료하였습니다. 
