### PR TITLE
websecurityconfig 수정 및 application-docker.properties 8080포트 지정

### DIFF
--- a/src/main/java/com/bod/bod/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/bod/bod/global/config/WebSecurityConfig.java
@@ -53,6 +53,7 @@ public class WebSecurityConfig {
 
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(HttpMethod.POST, "/api/**").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/**").permitAll()
 				.requestMatchers(HttpMethod.POST, "/api/signup/**").permitAll()
 				.requestMatchers(HttpMethod.POST, "/api/users/**").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/challenges/**").permitAll()

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -63,3 +63,5 @@ spring.mail.smtp.port=${SMTP_PORT}
 spring.mail.username=${SMTP_USERNAME}
 spring.mail.password=${SMTP_PASSWORD}
 spring.mail.smtp.address=${SMTP_ADDRESS}
+
+server.port=8080


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/1974c448-50b6-4b02-80b8-8d0452eff6eb)
.requestMatchers(HttpMethod.GET, "/api/**").permitAll()  추가

![image](https://github.com/user-attachments/assets/eb604c1c-7c28-45b3-8f5a-dd1e76471f85)
포트 지정